### PR TITLE
Add support for body arrays

### DIFF
--- a/lib/snippets-plus.js
+++ b/lib/snippets-plus.js
@@ -813,6 +813,10 @@ function buildSnippets(snippetsDefinition) {
         attributes.prefix = name;
       }
 
+      if (Array.isArray(attributes.body)) {
+        attributes.body = attributes.body.join('\n');
+      }
+
       if (
         (typeof attributes.prefix !== "string" && attributes.prefix !== null) ||
         typeof attributes.body !== "string"


### PR DESCRIPTION
This PR is the first proposal to abolish the second-class citizenship of JSON snippets. We all know the developers of Atom embraced CoffeeScript (alongside CSON) for their own reasons, and that's fine. CSON snippets can be more readable for a variety of reasons, multi-line strings being one of them.

**CoffeeScript**

```coffee
".source.js":
  "if":
    "prefix": "_if"
    "body": """
      if (${1:condition}) {
        $2
      }
    """
```

**JavaScript**

```js
{
  ".source.js": {
    "if": {
      "prefix": "_if",
      "body": "if (${1:condition}) {\n  $2\n}"
    }
  }
}
```

Naturally, the CSON snippet is much easier to read and maintain. VSCode has modelled its snippets format after Atom's, with one minor difference that improves the above problem, the body of a snippet can also be an array:

```js
{
  ".source.js": {
    "if": {
      "prefix": "_if",
      "body": [
        "if (${1:condition}) {",
        "  $2",
        "}"
      ]
    }
  }
}
```

Still not as good to read as CSON, but arguably much better.

I could further see comments being supported through a JSONC (or JSON5) parser – or even introducing YAML as a third option. But I'd love to hear your thoughts first.